### PR TITLE
Adding --output_pdf option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,7 +2145,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vitepress-pdf-export"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vitepress-pdf-export"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 authors = ["Jonathan Parris jparris@ddn.com"]
 license-file = "LICENSE"

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,10 @@ struct Args {
     #[arg(short = 'c', long)]
     config: PathBuf,
 
+    /// Overwrite the `output_pdf` defined in the config file
+    #[arg(short = 'o', long)]
+    output_pdf: Option<PathBuf>,
+
     /// Directory to save individual PDFs into.
     ///
     /// If this option is not defined individual PDFs will be removed.
@@ -51,7 +55,11 @@ async fn main() -> Result<ExitCode> {
     if args.merge_only && args.map.is_none() {
         println!("--map must defined when --merge_only")
     }
-    let config = Config::load(&args.config)?;
+    let mut config = Config::load(&args.config)?;
+
+    if let Some(output_pdf) = args.output_pdf {
+        config.output_pdf = output_pdf;
+    }
 
     let temp_dir = tempdir()?;
 


### PR DESCRIPTION
```
  ████████████████████ 33/33 rendering http://localhost:5173/exascaler-procedures/how-to-work-with-repo-rpms.html     
Merged PDF is available here foo.pdf

grep output_pdf conf/vitepress-pdf-export.toml 
output_pdf = "EXAScaler-6.3.1-features-and-procedures-guide.pdf"
```