### PR TITLE
Fixing Clap Options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,7 +2145,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vitepress-pdf-export"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vitepress-pdf-export"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Jonathan Parris jparris@ddn.com"]
 license-file = "LICENSE"

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ struct Args {
     ///
     /// The idea is run `vitepress --keep_pdfs pdfs --map map.json` which
     /// will render out the pdfs then run `vitepress --merge-onlys --map map.json`
-    #[arg(short = 'o', long, action)]
+    #[arg(long, action)]
     merge_only: bool,
 }
 
@@ -88,4 +88,15 @@ async fn main() -> Result<ExitCode> {
     }
 
     merge_pdfs(&config, url_to_pdf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Args;
+    use clap::CommandFactory as _;
+
+    #[test]
+    fn verify_cli() {
+        Args::command().debug_assert()
+    }
 }


### PR DESCRIPTION
```
/vitepress-pdf-export on  jparris/fix_clap_options cargo test
   ...

running 3 tests
test tests::verify_cli ... ok
test merge::tests::test_rewrite_urls ... ok
test merge::tests::test_merge_toc ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
```